### PR TITLE
Add include/drivers from rt-kernel to the include path

### DIFF
--- a/Platform/rt-kernel.cmake
+++ b/Platform/rt-kernel.cmake
@@ -57,6 +57,7 @@ list (APPEND INCLUDES
   ${RTK}/bsp/${BSP}/include
   ${RTK}/include
   ${RTK}/include/arch/${ARCH}
+  ${RTK}/include/drivers
   ${RTK}/lwip/src/include
   )
 set(CMAKE_ASM_STANDARD_INCLUDE_DIRECTORIES ${INCLUDES})


### PR DESCRIPTION
Many BSP headers in older kernel trees include <net.h> which is not
found otherwise.