### PR TITLE
Enable placing the BSP outside the kernel tree

### DIFF
--- a/Platform/rt-kernel.cmake
+++ b/Platform/rt-kernel.cmake
@@ -54,7 +54,7 @@ add_definitions(
 
 # Common includes
 list (APPEND INCLUDES
-  ${RTK}/bsp/${BSP}/include
+  ${BSP_DIR}/include
   ${RTK}/include
   ${RTK}/include/arch/${ARCH}
   ${RTK}/lwip/src/include
@@ -67,7 +67,8 @@ set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${INCLUDES})
 add_link_options(
   -nostartfiles
   -L${RTK}/lib/${ARCH}/${VARIANT}/${CPU}
-  -T${RTK}/bsp/${BSP}/${BSP}.ld
+  -L${BSP_LIBDIR}
+  -T${BSP_DIR}/${BSP}.ld
   -Wl,--gc-sections
   )
 
@@ -93,7 +94,6 @@ list (APPEND LIBS
   -lpwm
   -ladc
   -ldac
-  -ltrace
   -lcounter
   -lshell
   -llua

--- a/toolchain/rt-kernel.cmake
+++ b/toolchain/rt-kernel.cmake
@@ -48,15 +48,22 @@ if (NOT DEFINED ENV{COMPILERS})
 endif()
 
 # Get environment variables
-set(RTK $ENV{RTK} CACHE STRING
+set(RTK $ENV{RTK} CACHE PATH
   "Location of rt-kernel tree")
-set(COMPILERS $ENV{COMPILERS} CACHE STRING
+set(COMPILERS $ENV{COMPILERS} CACHE PATH
   "Location of compiler toolchain")
 set(BSP $ENV{BSP} CACHE STRING
   "The name of the BSP to build for")
 
+if (NOT DEFINED ENV{BSP_DIR})
+  set(ENV{BSP_DIR} ${RTK}/bsp/${BSP})
+endif()
+
+set(BSP_DIR $ENV{BSP_DIR} CACHE PATH
+  "The location of the BSP to build for, may be out-of-tree from the rt-kernel")
+
 # Check that bsp.mk exists
-set(BSP_MK_FILE ${RTK}/bsp/${BSP}/${BSP}.mk)
+set(BSP_MK_FILE ${BSP_DIR}/${BSP}.mk)
 if (NOT EXISTS ${BSP_MK_FILE})
   message(FATAL_ERROR "Failed to open ${BSP_MK_FILE}")
 endif()
@@ -79,6 +86,13 @@ set(VARIANT ${CMAKE_MATCH_1} CACHE STRING "")
 # Get CROSS_GCC
 string(REGEX MATCH "CROSS_GCC=([A-Za-z0-9_\-]*)" _ ${BSP_MK})
 set(CROSS_GCC ${CMAKE_MATCH_1} CACHE STRING "")
+
+if (NOT DEFINED ENV{BSP_LIBDIR})
+  set(ENV{BSP_DIR} ${RTK}/lib/${ARCH}/${VARIANT}/${CPU})
+endif()
+
+set(BSP_LIBDIR $ENV{BSP_LIBDIR} CACHE PATH
+  "The location of the BSP library, may be out-of-tree from the rt-kernel")
 
 # Set cross-compiler toolchain
 set(CMAKE_C_COMPILER ${COMPILERS}/${CROSS_GCC}/bin/${CROSS_GCC}-gcc)


### PR DESCRIPTION
Preferably used with a rt-kernel that allows building without a BSP, or
at least one that is be built with an in-tree BSP which is based on the
same platform as the external one.

Don't link against the trace library, because it cannot be built without
a BSP in-tree, and it depends on possibly mismatching settings from that
BSP.