### PR TITLE
fix: ensure generate_bin handle changed filename

### DIFF
--- a/Platform/STM32Cube.cmake
+++ b/Platform/STM32Cube.cmake
@@ -75,6 +75,6 @@ set(CMAKE_CXX_STANDARD_LIBRARIES "${LIBS} -lstdc++")
 macro(generate_bin TARGET)
   add_custom_command(TARGET ${TARGET} POST_BUILD
     COMMAND ${OBJCOPY}
-    ARGS -O binary ${TARGET}.elf ${TARGET}.bin
+    ARGS -O binary $<TARGET_FILE:${TARGET}> $<TARGET_FILE_DIR:${TARGET}>/$<TARGET_FILE_BASE_NAME:${TARGET}>.bin
     )
 endmacro()

--- a/Platform/iMX8MM.cmake
+++ b/Platform/iMX8MM.cmake
@@ -148,6 +148,7 @@ set(CMAKE_CXX_STANDARD_LIBRARIES "${LIBS} -lstdc++")
 # Macro to add .bin output
 macro(generate_bin TARGET)
 add_custom_command(TARGET ${TARGET} POST_BUILD
-  COMMAND ${CMAKE_OBJCOPY} ARGS -O binary ${TARGET}.elf ${TARGET}.bin
+  COMMAND ${CMAKE_OBJCOPY}
+  ARGS -O binary $<TARGET_FILE:${TARGET}> $<TARGET_FILE_DIR:${TARGET}>/$<TARGET_FILE_BASE_NAME:${TARGET}>.bin
   )
 endmacro()


### PR DESCRIPTION
The targetname is not always the final file name,
it can be in a different directory and it can have different suffixes applied.