### PR TITLE
Updates to cmake build for tools

### DIFF
--- a/AddGoogleTest.cmake
+++ b/AddGoogleTest.cmake
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28)
 
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
   # gtest doesn't build on older GCC

--- a/AddGoogleTest.cmake
+++ b/AddGoogleTest.cmake
@@ -28,7 +28,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY      https://github.com/rtlabs-com/googletest.git
-  GIT_TAG             25808659d317cb03409e7949914b274e10e6824f
+  GIT_TAG             a0aa198b445e51f3d498b1603a6926abc0c244f6 # rt-labs/v1.14.0
   EXCLUDE_FROM_ALL
   )
 

--- a/AddGoogleTest.cmake
+++ b/AddGoogleTest.cmake
@@ -29,14 +29,13 @@ FetchContent_Declare(
   googletest
   GIT_REPOSITORY      https://github.com/rtlabs-com/googletest.git
   GIT_TAG             25808659d317cb03409e7949914b274e10e6824f
+  EXCLUDE_FROM_ALL
   )
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
-  set(INSTALL_GTEST OFF CACHE BOOL "")
-  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-  target_compile_options(gtest PRIVATE ${GTEST_COMPILE_OPTIONS})
-endif()
+
+set(INSTALL_GTEST OFF CACHE BOOL "")
+FetchContent_MakeAvailable(googletest)
+
+target_compile_options(gtest PRIVATE ${GTEST_COMPILE_OPTIONS})
 
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
   --force-new-ctest-process

--- a/AddOsal.cmake
+++ b/AddOsal.cmake
@@ -33,7 +33,7 @@
 # Finally, if OSAL is not found in the system it will be downloaded
 # and built automatically.
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28)
 
 if (NOT TARGET osal)
   # Attempt to find externally built OSAL

--- a/AddOsal.cmake
+++ b/AddOsal.cmake
@@ -46,15 +46,13 @@ if (NOT TARGET osal)
       osal
       GIT_REPOSITORY      https://github.com/rtlabs-com/osal.git
       GIT_TAG             57b4ae2
+      EXCLUDE_FROM_ALL
       )
-    FetchContent_GetProperties(osal)
-    if(NOT osal_POPULATED)
-      FetchContent_Populate(osal)
-      set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
-      set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "" FORCE)
-      add_subdirectory(${osal_SOURCE_DIR} ${osal_BINARY_DIR} EXCLUDE_FROM_ALL)
-      set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD} CACHE BOOL "" FORCE)
-    endif()
+
+    set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "" FORCE)
+    FetchContent_MakeAvailable(osal)
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD} CACHE BOOL "" FORCE)
 
     # Hide Osal_DIR to avoid confusion, as it is not used in this
     # configuration

--- a/Platform/STM32Cube.cmake
+++ b/Platform/STM32Cube.cmake
@@ -14,7 +14,7 @@
 #*******************************************************************/
 
 include_guard()
-cmake_minimum_required (VERSION 3.1.2)
+cmake_minimum_required (VERSION 3.28)
 enable_language(ASM)
 
 # Avoid warning when re-running cmake

--- a/Platform/iMX8MM.cmake
+++ b/Platform/iMX8MM.cmake
@@ -16,7 +16,7 @@
 #*******************************************************************/
 
 include_guard()
-cmake_minimum_required (VERSION 3.1.2)
+cmake_minimum_required (VERSION 3.28)
 enable_language(ASM)
 
 # Avoid warning when re-running cmake

--- a/Platform/rt-kernel.cmake
+++ b/Platform/rt-kernel.cmake
@@ -14,7 +14,7 @@
 #*******************************************************************/
 
 include_guard()
-cmake_minimum_required (VERSION 3.1.2)
+cmake_minimum_required (VERSION 3.28)
 
 # Avoid warning when re-running cmake
 set(DUMMY ${CMAKE_TOOLCHAIN_FILE})


### PR DESCRIPTION
- Bump cmake requirements to 3.28
- Switch to make available instead of fetch content
- Upgrade selected google test version to rt-labs/v1.14.0