### PR TITLE
Update osal with support for GCC builds on windows

### DIFF
--- a/AddOsal.cmake
+++ b/AddOsal.cmake
@@ -45,7 +45,7 @@ if (NOT TARGET osal)
     FetchContent_Declare(
       osal
       GIT_REPOSITORY      https://github.com/rtlabs-com/osal.git
-      GIT_TAG             57b4ae2
+      GIT_TAG             0a10a01
       EXCLUDE_FROM_ALL
       )
 


### PR DESCRIPTION
* FreeRTOS: Fix task stack size*
* FreeRTOS: CC_ASSERT() that xTaskCreate() succeeds
* feat: support building on windows with gcc
* Ensure CC_ASSERT calls do not have side effects